### PR TITLE
fix kubectl version

### DIFF
--- a/source/k8s-install/kubeadm-cn.rst
+++ b/source/k8s-install/kubeadm-cn.rst
@@ -136,7 +136,7 @@ kubeadm - 中国大陆版
 
     kubeadm version
     kubelet --version
-    kubectl version
+    kubectl version --client
 
 
 


### PR DESCRIPTION
`kubectl version`的作用是 `Print the client and server version information for the current context.`
在还没有安装好集群之前使用kubectl version会报错:
```shell
root@test-k8s:~# kubectl version
Client Version: v1.28.0
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```
所以改成`kubectl version --client`，结果是:
```shell
root@test-k8s:~# kubectl version --client
Client Version: v1.28.0
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
```